### PR TITLE
[Re #33] Fix nx svg loading error

### DIFF
--- a/apps/client/webpack.config.js
+++ b/apps/client/webpack.config.js
@@ -2,6 +2,7 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react/plugins/webpack');
 
+// https://github.com/nrwl/nx/issues/14378#issuecomment-1405312953
 module.exports = composePlugins(
   withNx(),
   withReact(),
@@ -10,12 +11,19 @@ module.exports = composePlugins(
       if (/file-loader/.test(rule.loader)) {
         return {
           ...rule,
+          test: /\.(eot|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)$/, 
           type: 'javascript/auto',
         };
       }
 
       return rule;
     });
+
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack', 'url-loader'],
+    });
+
     return config;
   },
 );


### PR DESCRIPTION
svg assets appeared to be broken in nx 15.6.2 Updated webpack config. 
Info - https://github.com/nrwl/nx/issues/14378#issuecomment-1405312953