### PR TITLE
[Related #65] Join and create room controllers

### DIFF
--- a/apps/server/src/controllers/create-tournament.controller.ts
+++ b/apps/server/src/controllers/create-tournament.controller.ts
@@ -1,0 +1,64 @@
+import {
+  PROTO_CREATE_LOBBY_ACCEPT,
+  PROTO_CREATE_LOBBY_REQUEST,
+} from '@razor/constants';
+import {
+  InitialClientData,
+  InitialServerData,
+  Snapshot,
+  socketId,
+} from '@razor/models';
+import { store } from '@razor/store';
+
+import { PubSubEvents } from '../models';
+import { pubsub } from '../services';
+import { tokenPlayerMap } from '../stores';
+
+interface JoinLobbyRequestArgs {
+  socketId: socketId;
+  data: InitialClientData;
+}
+
+pubsub.subscribe(
+  PROTO_CREATE_LOBBY_REQUEST,
+  ({ socketId, data }: JoinLobbyRequestArgs) => {
+    const { playerName } = data;
+    const playerId = store.dispatch.game.joinPlayer({
+      receivedTournamentId: '',
+      playerName,
+    });
+    if (!playerId) {
+      return;
+    }
+    tokenPlayerMap.addPlayerId(socketId, playerId);
+
+    const state = store.getState().game;
+    const player = state.playersModel[playerId];
+    const tournamentId = player.tournamentId;
+    const tournament = state.tournamentsModel[tournamentId];
+
+    const snapshot: Snapshot = {
+      tournamentsModel: {
+        [tournamentId]: tournament,
+      },
+      playersModel: {
+        [playerId]: player,
+      },
+      racesModel: {},
+      leaderboardsModel: {},
+      playerLogsModel: {},
+    };
+
+    const initialServerData: InitialServerData = {
+      playerId,
+      tournamentId,
+      snapshot,
+    };
+
+    pubsub.publish(PubSubEvents.SendDataToClient, {
+      playerId,
+      protocol: PROTO_CREATE_LOBBY_ACCEPT,
+      data: initialServerData,
+    });
+  },
+);

--- a/apps/server/src/controllers/create-tournament.controller.ts
+++ b/apps/server/src/controllers/create-tournament.controller.ts
@@ -11,26 +11,33 @@ import {
 import { store } from '@razor/store';
 
 import { PubSubEvents } from '../models';
-import { pubsub } from '../services';
+import { ContextOutput, Logger, pubsub } from '../services';
 import { tokenPlayerMap } from '../stores';
 
 interface JoinLobbyRequestArgs {
   socketId: socketId;
   data: InitialClientData;
+  context: ContextOutput;
 }
+
+const logger = new Logger('create-tournament.controller');
 
 pubsub.subscribe(
   PROTO_CREATE_LOBBY_REQUEST,
-  ({ socketId, data }: JoinLobbyRequestArgs) => {
+  ({ socketId, data, context }: JoinLobbyRequestArgs) => {
     const { playerName } = data;
     const playerId = store.dispatch.game.joinPlayer({
       receivedTournamentId: '',
       playerName,
     });
     if (!playerId) {
+      logger.error("Store didn't send a playerId", context);
       return;
     }
+    logger.debug('Player added to the store', context);
+
     tokenPlayerMap.addPlayerId(socketId, playerId);
+    logger.debug('Player added to tokenPlayerMap', context);
 
     const state = store.getState().game;
     const player = state.playersModel[playerId];

--- a/apps/server/src/controllers/join-tournament.controller.ts
+++ b/apps/server/src/controllers/join-tournament.controller.ts
@@ -1,0 +1,76 @@
+import {
+  PROTO_JOIN_LOBBY_ACCEPT,
+  PROTO_JOIN_LOBBY_REQUEST,
+} from '@razor/constants';
+import {
+  InitialClientData,
+  InitialServerData,
+  Snapshot,
+  socketId,
+  TournamentId,
+} from '@razor/models';
+import { store } from '@razor/store';
+import { pick } from 'lodash';
+
+import { PubSubEvents } from '../models';
+import { pubsub } from '../services';
+import { tokenPlayerMap } from '../stores';
+
+interface JoinLobbyRequestArgs {
+  socketId: socketId;
+  data: InitialClientData;
+}
+
+pubsub.subscribe(
+  PROTO_JOIN_LOBBY_REQUEST,
+  ({ socketId, data }: JoinLobbyRequestArgs) => {
+    const { playerName, roomId } = data;
+    const receivedTournamentId: TournamentId = `T:${roomId}`;
+    const playerId = store.dispatch.game.joinPlayer({
+      receivedTournamentId,
+      playerName,
+    });
+    if (!playerId) {
+      return;
+    }
+    tokenPlayerMap.addPlayerId(socketId, playerId);
+
+    const state = store.getState().game;
+    const player = state.playersModel[playerId];
+    const tournamentId = player.tournamentId;
+    const tournament = state.tournamentsModel[tournamentId];
+    const playerIds = tournament.playerIds;
+    const raceIds = tournament.raceIds;
+    const lastRaceId = raceIds[raceIds.length - 1];
+    const filteredPlayers = pick(state.playersModel, playerIds);
+    const filteredRaces = pick(state.playersModel, raceIds);
+    const filteredLeaderboards = pick(state.leaderboardsModel, raceIds);
+    let filteredPlayersLogs = {};
+    if (filteredRaces[lastRaceId]?.isOnGoing === true) {
+      const playersLogsIds = playerIds.map(playerId => lastRaceId + playerId);
+      filteredPlayersLogs = pick(state.playerLogsModel, playersLogsIds);
+    }
+
+    const snapshot: Snapshot = {
+      tournamentsModel: {
+        [tournamentId]: tournament,
+      },
+      playersModel: filteredPlayers,
+      racesModel: filteredRaces,
+      leaderboardsModel: filteredLeaderboards,
+      playerLogsModel: filteredPlayersLogs,
+    };
+
+    const initialServerData: InitialServerData = {
+      playerId,
+      tournamentId,
+      snapshot,
+    };
+
+    pubsub.publish(PubSubEvents.SendDataToClient, {
+      playerId,
+      protocol: PROTO_JOIN_LOBBY_ACCEPT,
+      data: initialServerData,
+    });
+  },
+);

--- a/apps/server/src/controllers/join-tournament.controller.ts
+++ b/apps/server/src/controllers/join-tournament.controller.ts
@@ -13,17 +13,20 @@ import { store } from '@razor/store';
 import { pick } from 'lodash';
 
 import { PubSubEvents } from '../models';
-import { pubsub } from '../services';
+import { ContextOutput, Logger, pubsub } from '../services';
 import { tokenPlayerMap } from '../stores';
 
 interface JoinLobbyRequestArgs {
   socketId: socketId;
   data: InitialClientData;
+  context: ContextOutput;
 }
+
+const logger = new Logger('create-tournament.controller');
 
 pubsub.subscribe(
   PROTO_JOIN_LOBBY_REQUEST,
-  ({ socketId, data }: JoinLobbyRequestArgs) => {
+  ({ socketId, data, context }: JoinLobbyRequestArgs) => {
     const { playerName, roomId } = data;
     const receivedTournamentId: TournamentId = `T:${roomId}`;
     const playerId = store.dispatch.game.joinPlayer({
@@ -31,9 +34,13 @@ pubsub.subscribe(
       playerName,
     });
     if (!playerId) {
+      logger.error("Store didn't send a playerId", context);
       return;
     }
+    logger.debug('Player added to the store', context);
+
     tokenPlayerMap.addPlayerId(socketId, playerId);
+    logger.debug('Player added to tokenPlayerMap', context);
 
     const state = store.getState().game;
     const player = state.playersModel[playerId];

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -5,6 +5,7 @@ import {
   RECONNECT_WAITING_TIME,
 } from '@razor/constants';
 import { AuthToken } from '@razor/models';
+import { store } from '@razor/store';
 import express from 'express';
 import http from 'http';
 import { Server } from 'socket.io';
@@ -23,7 +24,13 @@ const port = process.env.PORT || 3000;
 const server = http.createServer(app);
 
 app.get('/', (req, res) => {
-  res.send('Hello World!');
+  const storeState = store.getState();
+  res.send(storeState);
+});
+
+app.get('/token-player-map', (req, res) => {
+  const data = tokenPlayerMap.viewMap();
+  res.send(data);
 });
 
 const allowedOrigin =

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -108,13 +108,14 @@ io.on('connection', socket => {
     ) {
       // If player is new, player may not have playerId yet. So we use socket id to create context and publish event.
       // Player id will be created in the controller.
+      // TODO: If player has a playerId what should we do?
       const socketId = socket.id;
       context = logger.createContext({ identifier: socketId });
-      pubsub.publish(event, { socketId, data });
+      pubsub.publish(event, { socketId, data, context });
     } else {
       const playerId = tokenPlayerMap.getPlayerIdBySocketId(socket.id);
       context = logger.createContext({ identifier: playerId });
-      pubsub.publish(event, { playerId, data });
+      pubsub.publish(event, { playerId, data, context });
     }
     logger.info(`Protocol: ${event} | Message received.`, context, data);
   });

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,5 +1,7 @@
 import {
   PROTO_AUTH_TOKEN_TRANSFER,
+  PROTO_CREATE_LOBBY_REQUEST,
+  PROTO_JOIN_LOBBY_REQUEST,
   RECONNECT_WAITING_TIME,
 } from '@razor/constants';
 import { AuthToken } from '@razor/models';
@@ -8,9 +10,12 @@ import http from 'http';
 import { Server } from 'socket.io';
 import { v4 as uuidv4 } from 'uuid';
 
+import './controllers/join-tournament.controller';
+import './controllers/create-tournament.controller';
+
 import { pubsub } from './services/pubsub';
 import { PubSubEvents } from './models';
-import { Logger } from './services';
+import { ContextOutput, Logger } from './services';
 import { tokenPlayerMap } from './stores';
 
 const app = express();
@@ -43,9 +48,9 @@ const reconnect = (authToken: AuthToken): void => {
     const { socketId, playerId } = tokenPlayerMap.getPlayer(authToken);
     const context = logger.createContext({ identifier: playerId });
 
-    // If player still not connected then delete the player from map.
     const isSocketConnected = io.sockets.sockets.get(socketId)?.connected;
     if (!isSocketConnected) {
+      // If player still not connected then delete the player from map.
       tokenPlayerMap.clearPlayer(authToken);
       logger.debug(
         `User deleted from the map after waiting for ${RECONNECT_WAITING_TIME}ms.`,
@@ -72,15 +77,15 @@ io.on('connection', socket => {
 
   let newToken = '';
   if (!playerData) {
+    // If player is new token will be generated and sent to the client.
     newToken = uuidv4();
     socket.emit(PROTO_AUTH_TOKEN_TRANSFER, newToken);
-    // TODO: Add player to map should need plyaer id which needs to be generated in the join player controller
-    // So, following method should be called in the join player controller later.
-    const playerId = 'P:12345678';
-    tokenPlayerMap.addPlayer(newToken, playerId, socket.id);
-    const context = logger.createContext({ identifier: playerId });
+    // New player will be added with related socket id to the map.
+    tokenPlayerMap.addSocketId(newToken, socket.id);
+    const context = logger.createContext({ identifier: socket.id });
     logger.debug('New user added to map.', context);
   } else {
+    // If player is already in the map then update the socket id.
     tokenPlayerMap.updatePlayerSocketId(token, socket.id);
     const { playerId } = playerData;
     const context = logger.createContext({ identifier: playerId });
@@ -88,14 +93,26 @@ io.on('connection', socket => {
   }
 
   // On any socket event publish the event with playerId and data.
-  socket.onAny((event, ...data) => {
-    const playerId = tokenPlayerMap.getPlayerIdBySocketId(socket.id);
-    const context = logger.createContext({ identifier: playerId });
-    logger.info(`Protocol: ${event} | Message received.`, context);
-    pubsub.publish(event, { playerId, data });
+  socket.onAny((event, data) => {
+    let context: ContextOutput;
+    if (
+      event === PROTO_JOIN_LOBBY_REQUEST ||
+      event === PROTO_CREATE_LOBBY_REQUEST
+    ) {
+      // If player is new, player may not have playerId yet. So we use socket id to create context and publish event.
+      // Player id will be created in the controller.
+      const socketId = socket.id;
+      context = logger.createContext({ identifier: socketId });
+      pubsub.publish(event, { socketId, data });
+    } else {
+      const playerId = tokenPlayerMap.getPlayerIdBySocketId(socket.id);
+      context = logger.createContext({ identifier: playerId });
+      pubsub.publish(event, { playerId, data });
+    }
+    logger.info(`Protocol: ${event} | Message received.`, context, data);
   });
 
-  // If a user disconnects call the reconnect function.
+  // If a user disconnected call the reconnect function.
   socket.on('disconnect', () => {
     const playerId = tokenPlayerMap.getPlayerIdBySocketId(socket.id);
     const authToken = tokenPlayerMap.getAuthTokenBySocketId(socket.id);

--- a/apps/server/src/stores/token-player-map.ts
+++ b/apps/server/src/stores/token-player-map.ts
@@ -12,12 +12,18 @@ interface mapAsObject {
 class TokenPlayerMap {
   private map: Map<AuthToken, MapData> = new Map<PlayerId, MapData>();
 
-  // add socket id when connection established
+  /** Create new map entry with auth token and socket Id.
+   * @param authToken - auth token of the player
+   * @param socketId - socket id of the player
+   */
   addSocketId(authToken: AuthToken, socketId: socketId): void {
     this.map.set(authToken, { socketId });
   }
 
-  // add player id using socket id
+  /** Add player id to the existing map entry.
+   * @param socketId - socket id of the player
+   * @param playerId - player id of the player
+   */
   addPlayerId(socketId: socketId, playerId: PlayerId): void {
     for (const [key, value] of this.map.entries()) {
       if (value.socketId === socketId) {
@@ -72,6 +78,9 @@ class TokenPlayerMap {
     return null;
   }
 
+  /** Get all entries
+   * @returns - map as a object
+   */
   viewMap(): mapAsObject {
     return Object.fromEntries(this.map);
   }

--- a/apps/server/src/stores/token-player-map.ts
+++ b/apps/server/src/stores/token-player-map.ts
@@ -5,6 +5,10 @@ interface MapData {
   socketId: socketId;
 }
 
+interface mapAsObject {
+  [key: string]: MapData;
+}
+
 class TokenPlayerMap {
   private map: Map<AuthToken, MapData> = new Map<PlayerId, MapData>();
 
@@ -68,8 +72,8 @@ class TokenPlayerMap {
     return null;
   }
 
-  viewMap(): string {
-    return JSON.stringify(Array.from(this.map.entries()));
+  viewMap(): mapAsObject {
+    return Object.fromEntries(this.map);
   }
 
   // clear player after retries

--- a/apps/server/src/stores/token-player-map.ts
+++ b/apps/server/src/stores/token-player-map.ts
@@ -1,19 +1,25 @@
 import { AuthToken, PlayerId, socketId } from '@razor/models';
 
 interface MapData {
-  playerId: PlayerId;
+  playerId?: PlayerId;
   socketId: socketId;
 }
 
 class TokenPlayerMap {
   private map: Map<AuthToken, MapData> = new Map<PlayerId, MapData>();
 
-  addPlayer(
-    authToken: AuthToken,
-    playerId: PlayerId,
-    socketId: socketId,
-  ): void {
-    this.map.set(authToken, { playerId, socketId });
+  // add socket id when connection established
+  addSocketId(authToken: AuthToken, socketId: socketId): void {
+    this.map.set(authToken, { socketId });
+  }
+
+  // add player id using socket id
+  addPlayerId(socketId: socketId, playerId: PlayerId): void {
+    for (const [key, value] of this.map.entries()) {
+      if (value.socketId === socketId) {
+        this.map.set(key, { ...value, playerId });
+      }
+    }
   }
 
   getPlayer(authToken: AuthToken): MapData | null {
@@ -62,8 +68,8 @@ class TokenPlayerMap {
     return null;
   }
 
-  viewMap(): void {
-    console.log(this.map);
+  viewMap(): string {
+    return JSON.stringify(Array.from(this.map.entries()));
   }
 
   // clear player after retries

--- a/docs/communication/protocol/create-tournament.md
+++ b/docs/communication/protocol/create-tournament.md
@@ -102,7 +102,14 @@ Socket message
 "data": {
     "playerId": PLAYER_ID,
     "tournamentId": TOURNAMENT_ID,
-    "snapshot": {} // Empty Snapshot
+    "snapshot": {
+        "tournamentsModel": <Tournament>[],
+        "playersModel": <Player>[],
+        // Empty objects (because tournament is new)
+        "racesModel": {},
+        "leaderboardsModel": {},
+        "playerLogsModel": {},
+    }
 }
 ```
 

--- a/docs/communication/protocol/join-tournament.md
+++ b/docs/communication/protocol/join-tournament.md
@@ -93,12 +93,11 @@ Socket message
     "playerId": PLAYER_ID,
     "tournamentId": TOURNAMENT_ID,
     "snapshot": {
-        "stateModelSegment": {
-            "playersModel": <Player>[],
-            "tournamentsModel": <Tournament>[],
-            "racesModel": <Race>[],
-            "leaderboardsModel": <Leaderboard>[]
-        }
+        "tournamentsModel": <Tournament>[],
+        "playersModel": <Player>[],
+        "racesModel": <Race>[],
+        "leaderboardsModel": <Leaderboard>[],
+        "playerLogsModel": <PlayerLogs>[], // Only if player joins while race is ongoing.
     }
 }
 ```

--- a/libs/store/src/lib/effects/index.ts
+++ b/libs/store/src/lib/effects/index.ts
@@ -1,7 +1,1 @@
-//Exporting effects
-
 export * from './effects';
-export * from './logger';
-export * from './player';
-export * from './race';
-export * from './tournament';

--- a/libs/store/src/lib/effects/player.ts
+++ b/libs/store/src/lib/effects/player.ts
@@ -6,6 +6,7 @@ import {
   AppPlayerLogId,
   AppPlayerState,
   AppTournamentState,
+  PlayerId,
 } from '@razor/models';
 import { generateAvatarLink, generateUid } from '@razor/util';
 
@@ -48,7 +49,7 @@ export const joinPlayer = (
   dispatch: Dispatch,
   payload: JoinPlayerPayload,
   state: RootState,
-): void => {
+): PlayerId | void => {
   const { receivedTournamentId, playerName } = payload;
   // Tournament id with correct format.
   let tournamentId;
@@ -127,6 +128,8 @@ export const joinPlayer = (
       tournamentId,
     },
   });
+
+  return playerId;
 };
 
 /** Effect function for clearing player.


### PR DESCRIPTION
Related https://github.com/the-ai-team/razor/issues/65
- Update protocol docs on data sending when a player joins or creates a room.
- Create controllers for creating tournaments and joining tournaments.
- Update token-player map
- Update join player effect to return player id
- Make store state and token player map viewable
- Pass logger context to pubsub.